### PR TITLE
Improve collection item page layout and traceability rendering; add mock/demo item and field ordering

### DIFF
--- a/studio/src/api.ts
+++ b/studio/src/api.ts
@@ -107,6 +107,9 @@ export interface CollectionItem {
 export interface CitationItemRef {
   kind: string;
   item_id: string;
+  label?: string;
+  title?: string;
+  name?: string;
 }
 
 /** One citation: external (url) or internal (item_ref). */
@@ -121,6 +124,9 @@ export interface Citation {
 export interface DerivedFrom {
   kind: string;
   item_id: string;
+  label?: string;
+  title?: string;
+  name?: string;
 }
 
 /** Keys that are rendered by TraceabilityDisplay, not as generic fields. */

--- a/studio/src/components/display/TraceabilityDisplay.tsx
+++ b/studio/src/components/display/TraceabilityDisplay.tsx
@@ -17,6 +17,17 @@ function getDerivedFrom(item: CollectionItem): DerivedFrom[] {
   );
 }
 
+function humanizeIdentifier(value: string): string {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function getRefDisplayName(ref: { label?: string; title?: string; name?: string; item_id: string }): string {
+  return ref.label ?? ref.title ?? ref.name ?? humanizeIdentifier(ref.item_id);
+}
+
 function getReasoning(item: CollectionItem): string | null {
   const r = item.reasoning;
   return typeof r === "string" && r.trim() ? r : null;
@@ -74,12 +85,17 @@ export function TraceabilityDisplay({
                     {c.title ?? c.url}
                   </a>
                 ) : c.item_ref ? (
-                  <Link
-                    to={getItemUrl(c.item_ref.kind, c.item_ref.item_id, runId ?? undefined)}
-                    className="text-primary hover:underline"
-                  >
-                    {c.item_ref.kind} #{c.item_ref.item_id}
-                  </Link>
+                  <>
+                    <Link
+                      to={getItemUrl(c.item_ref.kind, c.item_ref.item_id, runId ?? undefined)}
+                      className="text-primary hover:underline"
+                    >
+                      {getRefDisplayName(c.item_ref)}
+                    </Link>
+                    <span className="block text-muted-foreground text-xs mt-0.5 pl-4">
+                      {humanizeIdentifier(c.item_ref.kind)}
+                    </span>
+                  </>
                 ) : (
                   <span className="text-muted-foreground">—</span>
                 )}
@@ -105,8 +121,11 @@ export function TraceabilityDisplay({
                   to={getItemUrl(d.kind, d.item_id, runId ?? undefined)}
                   className="text-primary hover:underline"
                 >
-                  {d.kind} #{d.item_id}
+                  {getRefDisplayName(d)}
                 </Link>
+                <span className="block text-muted-foreground text-xs mt-0.5 pl-4">
+                  {humanizeIdentifier(d.kind)}
+                </span>
               </li>
             ))}
           </ul>

--- a/studio/src/pages/CollectionItemPage.tsx
+++ b/studio/src/pages/CollectionItemPage.tsx
@@ -13,6 +13,50 @@ import { downloadCollectionItemAsPdf } from "@/lib/collectionItemToPdf";
 import { FileDown } from "lucide-react";
 
 const EXCLUDE_KEYS = new Set(["id", "source_refs", ...TRACEABILITY_KEYS]);
+const TECHNICAL_FIELD_KEYS = new Set(["run_id", "created_at", "created_by_node_id", "created_by_node_result_id", "url"]);
+
+const MOCK_COLLECTION_ITEM: CollectionItem = {
+  id: "demo-item-001",
+  run_id: "run_demo_ux_024",
+  created_at: "2026-02-18T09:23:00.000Z",
+  created_by_node_id: "synthesis_agent",
+  created_by_node_result_id: "node_result_53",
+  title: "Customer support quality is trending up after triage rewrite",
+  summary:
+    "The latest weekly support review indicates a measurable improvement in response quality and resolution confidence after introducing the new triage prompt.",
+  content:
+    "### Key finding\nAverage issue clarity improved from **3.1 → 4.2** in two weeks.\n\n### Why it matters\nClearer issue framing reduced back-and-forth and shortened average resolution time by 18%.\n\n### Suggested action\nRoll out the triage template to the onboarding queue and monitor escalation volume for two more cycles.",
+  confidence_score: 0.83,
+  citations: [
+    {
+      title: "Week 7 QA rubric",
+      url: "https://example.com/qa-rubric/week-7",
+      excerpt: "Issue clarity score rose in both billing and onboarding categories.",
+    },
+    {
+      item_ref: {
+        kind: "support_ticket",
+        item_id: "ticket-1882",
+        label: "Escalation thread: onboarding billing confusion",
+      },
+      excerpt: "Representative conversation showed fewer clarification loops.",
+    },
+  ],
+  derived_from: [
+    {
+      kind: "support_ticket",
+      item_id: "ticket-1882",
+      title: "Escalation thread: onboarding billing confusion",
+    },
+    {
+      kind: "weekly_metrics",
+      item_id: "metrics-2026-w07",
+      title: "Support quality metrics · Week 7",
+    },
+  ],
+  reasoning:
+    "The strongest signal is consistency across independent reviewers and cohorts, which lowers the chance that this is just sampling noise.",
+};
 
 function getSourceRefs(item: CollectionItem): SourceRef[] {
   const refs = item.source_refs;
@@ -33,6 +77,7 @@ export function CollectionItemPage() {
   const params = useParams<{ runId?: string; kind: string; itemId: string }>();
   const [searchParams] = useSearchParams();
   const runId = params.runId ?? searchParams.get("run_id") ?? null;
+  const useMockData = searchParams.get("mock") === "1";
   const kind = params.kind ?? "";
   const itemId = params.itemId ?? "";
   const { selectedWorkflowId } = useWorkflowSelection();
@@ -43,6 +88,11 @@ export function CollectionItemPage() {
 
   const load = useCallback(async () => {
     if (!kind || !itemId) return;
+    if (useMockData) {
+      setItem({ ...MOCK_COLLECTION_ITEM, id: itemId, run_id: runId ?? MOCK_COLLECTION_ITEM.run_id });
+      setError(null);
+      return;
+    }
     try {
       if (runId) {
         const store = await api.getCollections(runId, kind);
@@ -62,7 +112,7 @@ export function CollectionItemPage() {
       setError(e instanceof Error ? e.message : String(e));
       setItem(null);
     }
-  }, [kind, itemId, runId]);
+  }, [kind, itemId, runId, useMockData]);
 
   useEffect(() => {
     load();
@@ -118,6 +168,37 @@ export function CollectionItemPage() {
   const displayKind = kind.replace(/_/g, " ");
   const step = getCreatedByNodeId(item);
   const sourceRefs = getSourceRefs(item);
+  const orderedFields = Object.entries(item)
+    .filter(([k]) => !EXCLUDE_KEYS.has(k))
+    .filter(([, value]) => value !== undefined && value !== null)
+    .sort(([a], [b]) => {
+      const rank = (key: string): number => {
+        const lower = key.toLowerCase();
+        if (lower === "title" || lower.endsWith("_title")) return 0;
+        if (lower.includes("content") || lower.includes("summary") || lower.includes("description") || lower === "body") return 1;
+        if (TECHNICAL_FIELD_KEYS.has(lower) || lower.endsWith("_id") || lower.endsWith("_at")) return 3;
+        return 2;
+      };
+      const rankDiff = rank(a) - rank(b);
+      if (rankDiff !== 0) return rankDiff;
+      return a.localeCompare(b);
+    });
+
+  const primaryTitleField = orderedFields.find(([key]) => {
+    const lower = key.toLowerCase();
+    return lower === "title" || lower.endsWith("_title");
+  });
+  const primaryTitle = typeof primaryTitleField?.[1] === "string" ? (primaryTitleField[1] as string) : null;
+
+  const mainContentFields = orderedFields.filter(([key]) => {
+    const lower = key.toLowerCase();
+    if (primaryTitleField && key === primaryTitleField[0]) return false;
+    return !(TECHNICAL_FIELD_KEYS.has(lower) || lower.endsWith("_id") || lower.endsWith("_at"));
+  });
+  const technicalFields = orderedFields.filter(([key]) => {
+    const lower = key.toLowerCase();
+    return TECHNICAL_FIELD_KEYS.has(lower) || lower.endsWith("_id") || lower.endsWith("_at");
+  });
   const breadcrumbItems = runId
     ? [
         { label: "Runs", to: "/runs" as const },
@@ -132,7 +213,7 @@ export function CollectionItemPage() {
       ];
 
   return (
-    <div className="p-3 max-w-3xl mx-auto">
+    <div className="p-3 max-w-6xl mx-auto">
       <div className="flex items-center justify-between gap-2 mt-2">
         <Breadcrumbs items={breadcrumbItems} />
         <button
@@ -145,9 +226,15 @@ export function CollectionItemPage() {
           Download PDF
         </button>
       </div>
-      <article className="mt-6 space-y-8">
+      <article className="mt-6 grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+        <div className="space-y-8">
         <header>
-          <h1 className="text-2xl font-semibold tracking-tight">{displayKind}</h1>
+          <div className="flex items-center gap-2 mb-2">
+            <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              {displayKind}
+            </span>
+          </div>
+          <h1 className="text-2xl font-semibold tracking-tight">{primaryTitle ?? (item.id ? String(item.id) : "Untitled item")}</h1>
           <div className="flex flex-wrap items-center gap-2 mt-2 text-sm text-muted-foreground">
             {item.created_at && (
               <span>Added {formatTimestamp(item.created_at as string)}</span>
@@ -169,16 +256,7 @@ export function CollectionItemPage() {
           </div>
         </header>
         <div className="space-y-8">
-          <TraceabilityDisplay
-            item={item}
-            runId={runId ?? (item.run_id as string | undefined)}
-            headingLevel="h2"
-            className="space-y-6"
-          />
-          {Object.entries(item)
-            .filter(([k]) => !EXCLUDE_KEYS.has(k))
-            .map(([key, value]) => {
-              if (value === undefined || value === null) return null;
+          {mainContentFields.map(([key, value]) => {
               const label = key.replace(/_/g, " ");
               const isRich = shouldRenderRichText(key, value);
               const ref = references[key];
@@ -236,11 +314,48 @@ export function CollectionItemPage() {
                 </section>
               );
             })}
-          {sourceRefs.length > 0 && (
-            <section>
-              <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-                Sources
+          {technicalFields.length > 0 && (
+            <section className="space-y-4 border-t border-border pt-6">
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Technical details
               </h2>
+              <div className="space-y-4">
+                {technicalFields.map(([key, value]) => {
+                  const label = key.replace(/_/g, " ");
+                  return (
+                    <section key={key}>
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">{label}</h3>
+                      <p className="text-sm whitespace-pre-wrap break-words">{formatValue(value)}</p>
+                    </section>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+        </div>
+        </div>
+
+        <aside className="space-y-4 lg:sticky lg:top-4 self-start">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm">Evidence & Traceability</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <TraceabilityDisplay
+                item={item}
+                runId={runId ?? (item.run_id as string | undefined)}
+                headingLevel="h3"
+                className="space-y-5"
+              />
+            </CardContent>
+          </Card>
+          {sourceRefs.length > 0 && (
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-sm">Sources</CardTitle>
+              </CardHeader>
+              <CardContent>
+            <section>
               <ul className="list-disc list-inside space-y-1 text-sm">
                 {sourceRefs.map((ref, i) => (
                   <li key={ref.id}>
@@ -260,8 +375,10 @@ export function CollectionItemPage() {
                 ))}
               </ul>
             </section>
+              </CardContent>
+            </Card>
           )}
-        </div>
+        </aside>
       </article>
     </div>
   );


### PR DESCRIPTION
### Motivation

- Make collection item details more readable by surfacing a primary title, ordering fields by importance, and separating technical metadata.  
- Improve traceability UI by showing human-friendly labels for item references and a clearer citation/derived-from presentation.  
- Add a demo/mock item path for local development and exploration of the UI without backend data.

### Description

- Extended API types by adding optional `label`, `title`, and `name` to `CitationItemRef` and `DerivedFrom` so reference display can prefer human-friendly identifiers.  
- Enhanced `TraceabilityDisplay` with `humanizeIdentifier` and `getRefDisplayName`, using `label/title/name` fallbacks and showing a small humanized kind label under links.  
- Reworked `CollectionItemPage` to compute an ordered field list, pick a `primaryTitle`, separate `mainContentFields` and `technicalFields`, and render a wider two-column layout with a sticky aside for Evidence & Traceability and Sources.  
- Added `MOCK_COLLECTION_ITEM` and a `mock=1` query param (via `useMockData`) to load demo data for local development, and exposed a `TECHNICAL_FIELD_KEYS` set to control field grouping.  
- Preserved existing behaviors like rich-text rendering via `RichText`, collection reference linking, and PDF download while improving visual hierarchy and accessibility of traceability details.

### Testing

- Performed TypeScript type-check using `tsc --noEmit` with no type errors reported.  
- Ran the project build with `yarn build` and confirmed the build succeeds.  
- Executed the test suite with `yarn test` and observed tests passing (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7369ff384832d8c3595707a58891e)