### PR TITLE
fix: render object/array values in run input display

### DIFF
--- a/studio/src/pages/RunDetailPage.tsx
+++ b/studio/src/pages/RunDetailPage.tsx
@@ -297,6 +297,8 @@ export function RunDetailPage() {
                       <dd className="min-w-0 break-words">
                         {typeof v === "string" && v.length > 200 ? (
                           <span className="block rounded bg-muted/50 p-2 text-xs whitespace-pre-wrap">{v}</span>
+                        ) : typeof v === "object" ? (
+                          <span className="block rounded bg-muted/50 p-2 text-xs whitespace-pre-wrap font-mono">{JSON.stringify(v, null, 2)}</span>
                         ) : (
                           <span className="rounded bg-muted/50 px-1.5 py-0.5">{String(v)}</span>
                         )}


### PR DESCRIPTION
## Problem

The run detail page displays `[object Object]` for run input values that are arrays or objects (e.g., **Pending Review Items**, **Key Changes Summary**).

![Screenshot showing the bug](https://github.com/user-attachments/assets/placeholder)

### Root Cause

In `RunDetailPage.tsx`, line 301 uses `String(v)` to render all non-long-string values. When `v` is an array or object, `String()` produces `[object Object]` instead of useful output.

## Fix

Added an explicit check for `typeof v === 'object'` before the `String(v)` fallback. Object/array values are now rendered as formatted JSON (`JSON.stringify(v, null, 2)`) in a code-style block with monospace font, matching the existing long-string treatment.

### Before
```
Pending Review Items: [object Object],[object Object],[object Object],[object Object]
Key Changes Summary: [empty]
```

### After
```json
Pending Review Items:
[
  { "id": "t1", "description": "Fix automated-roll-..." },
  ...
]
```

## Changes

- `studio/src/pages/RunDetailPage.tsx` — Added object type check with JSON.stringify rendering (2 lines changed)